### PR TITLE
Update instructions and formatting of readme and fix scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ git clone https://github.com/bkerler/mtkclient -b 1.9
 
 ## Prepare your device:
 
-- Create a full backup of your device using the MTKClient, either through the GUI using `python mtk_gui` or through `python mtk rl out`.
+- Create a full backup of your device using the MTKClient, either through either the GUI: `python mtk_gui` or the CLI: `python mtk rl out`.
 - Unlock your bootloader:
     - Enable and open 'Developer Options'.
     - Enable 'USB debugging' and 'OEM Unlocking'.
@@ -28,13 +28,19 @@ fastboot --disable-verity --disable-verification flash vbmeta_system_b vbmeta_sy
 fastboot --disable-verity --disable-verification flash vbmeta_vendor_a vbmeta_vendor_a.bin
 fastboot --disable-verity --disable-verification flash vbmeta_vendor_a vbmeta_vendor_b.bin
 ```
-- Download the `super.img` from your device using MTKClient.
+- Download the `super.img` from your device using MTKClient or use the `super.bin` file from your backup (renamed to `super.img`).
 
 ## Use the scripts:
 
-- `./init.sh`                                  # set -eu 
-- `./ext/otatools/bin/lpunpack super.img .     # extract super
-- `./mountall.sh`                              # mount partitions into /tmp
-- `./safe-debloat.sh`                          # remove bloatware
-- `./unmountall.sh`                            # unmount partitions and remove /tmp
-- `./remake.sh`                                # remake your super into super.new.img
+- The scripts are used in following order. Note that `safe-debloat.sh` is not required, you can make your own modifications at that point.
+```
+./init.sh                                      # set -eu 
+./ext/otatools/bin/lpunpack super.img .        # extract super
+./mountall.sh                                  # mount partitions into /tmp
+
+# Make your own modifications to the partition(s). Or remove bloatware using the optional script: ./safe-debloat.sh
+
+./unmountall.sh                                # unmount partitions and remove /tmp
+./remake.sh                                    # remake your super into super.new.img
+```
+- Flash the remade `super.new.img` using either the GUI: `python mtk_gui` or the CLI: `python mtk w super super.new.img`.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,34 @@
-Prereqs:
+# Astro Super Tools
 
-OTATools ( https://drive.google.com/file/d/1h4sGXNI1Al5Y_Te9T8xMWrp3mHw1tke-/view )
+## Prerequisites:
 
-The SUPER IMG from your device.
+- Clone this repository: `git clone https://github.com/loopback7084/astro_super_tools`.
+- Download OTATools (https://drive.google.com/file/d/1h4sGXNI1Al5Y_Te9T8xMWrp3mHw1tke-/view), unpack and place in `astro_super_tools/ext/otatools`.
+- Clone mtkclient and place into `astro_super_tools/ext/mtkclient`: 
+```
+cd astro_super_tools/ext
+rm -rf mtkclient
+git clone https://github.com/bkerler/mtkclient -b 1.9
+```
 
-Unlocked Bootloader
+## Prepare your device:
 
-DMVerity Disabled on VBMETA, VBMETA_SYSTEM, VBMETA_VENDOR
+- Unlock your bootloader.
+- Disable DMVerity on VBMETA, VBMETA_SYSTEM, VBMETA_VENDOR using fastboot:
+``` 
+fastboot --disable-verity --disable-verification flash vbmeta_a vbmeta_a.bin
+fastboot --disable-verity --disable-verification flash vbmeta_b vbmeta_b.bin
+fastboot --disable-verity --disable-verification flash vbmeta_system_a vbmeta_system_a.bin
+fastboot --disable-verity --disable-verification flash vbmeta_system_b vbmeta_system_b.bin
+fastboot --disable-verity --disable-verification flash vbmeta_vendor_a vbmeta_vendor_a.bin
+fastboot --disable-verity --disable-verification flash vbmeta_vendor_a vbmeta_vendor_b.bin
+```
+- Download the SUPER IMG from your device using mtkclient.
 
-
-MTKClient:-
-
-For extracting the device firmware: https://github.com/bkerler/mtkclient
+## Use the scripts:
+- `./init.sh`                              # set -eu 
+- `./ext/otatools/bin/lpunpack super.img . # extract super
+- `./mountall.sh`                          # mount partitions into /tmp
+- `./safe-debloat.sh`                      # remove bloatware
+- `./unmountall.sh`                        # unmount partitions and remove /tmp
+- `./remake.sh`                            # remake your super into super.new.img

--- a/README.md
+++ b/README.md
@@ -13,8 +13,13 @@ git clone https://github.com/bkerler/mtkclient -b 1.9
 
 ## Prepare your device:
 
-- Unlock your bootloader.
-- Disable DMVerity on VBMETA, VBMETA_SYSTEM, VBMETA_VENDOR using fastboot:
+- Create a full backup of your device using the MTKClient, either through the GUI using `python mtk_gui` or through `python mtk rl out`.
+- Unlock your bootloader:
+    - Enable and open 'Developer Options'.
+    - Enable 'USB debugging' and 'OEM Unlocking'.
+    - Reboot into fastboot (reboot with `Vol -` pressed).
+    - Unlock bootloader using: `fastboot flashing unlock`.
+- Disable DMVerity on VBMETA, VBMETA_SYSTEM, VBMETA_VENDOR using fastboot by reflashing the vbmeta* bin files:
 ``` 
 fastboot --disable-verity --disable-verification flash vbmeta_a vbmeta_a.bin
 fastboot --disable-verity --disable-verification flash vbmeta_b vbmeta_b.bin
@@ -23,12 +28,13 @@ fastboot --disable-verity --disable-verification flash vbmeta_system_b vbmeta_sy
 fastboot --disable-verity --disable-verification flash vbmeta_vendor_a vbmeta_vendor_a.bin
 fastboot --disable-verity --disable-verification flash vbmeta_vendor_a vbmeta_vendor_b.bin
 ```
-- Download the SUPER IMG from your device using mtkclient.
+- Download the `super.img` from your device using MTKClient.
 
 ## Use the scripts:
-- `./init.sh`                              # set -eu 
-- `./ext/otatools/bin/lpunpack super.img . # extract super
-- `./mountall.sh`                          # mount partitions into /tmp
-- `./safe-debloat.sh`                      # remove bloatware
-- `./unmountall.sh`                        # unmount partitions and remove /tmp
-- `./remake.sh`                            # remake your super into super.new.img
+
+- `./init.sh`                                  # set -eu 
+- `./ext/otatools/bin/lpunpack super.img .     # extract super
+- `./mountall.sh`                              # mount partitions into /tmp
+- `./safe-debloat.sh`                          # remove bloatware
+- `./unmountall.sh`                            # unmount partitions and remove /tmp
+- `./remake.sh`                                # remake your super into super.new.img

--- a/safe-debloat.sh
+++ b/safe-debloat.sh
@@ -49,6 +49,8 @@ UNWANTED=(./system/system/app/agenda
     ./system/system/apex/com.google.android.cellbroadcast.apex
     ./system/system/app/GooglePrintRecommendationService)
 
+cd tmp
+
 for app in "${UNWANTED[@]}"; do
     rm -rf "${app}"
 done

--- a/unmountall.sh
+++ b/unmountall.sh
@@ -10,6 +10,8 @@ umount -v ./system
 umount -v ./vendor
 umount -v ./product
 
+cd ..
+
 e2fsck -fy system"${FW_SLOT}".img
 e2fsck -fy vendor"${FW_SLOT}".img
 e2fsck -fy product"${FW_SLOT}".img
@@ -19,3 +21,5 @@ resize2fs -M product"${FW_SLOT}".img
 e2fsck -fy system"${FW_SLOT}".img
 e2fsck -fy vendor"${FW_SLOT}".img
 e2fsck -fy product"${FW_SLOT}".img
+
+rm -rf tmp


### PR DESCRIPTION
This PR includes improved and expanded instructions and contains two fixes to the debloat & unmount scripts to properly make use of the ' /tmp' folder.