### PR TITLE
Update flash instructions to use fastboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 ## Prerequisites:
 
-- Clone this repository: `git clone https://github.com/loopback7084/astro_super_tools`.
+- Clone this repository: 
+```
+git clone https://github.com/loopback7084/astro_super_tools
+```
 - Download OTATools (https://drive.google.com/file/d/1h4sGXNI1Al5Y_Te9T8xMWrp3mHw1tke-/view), unpack and place in `astro_super_tools/ext/otatools`.
 - Clone mtkclient and place into `astro_super_tools/ext/mtkclient`: 
 ```
@@ -28,7 +31,7 @@ fastboot --disable-verity --disable-verification flash vbmeta_system_b vbmeta_sy
 fastboot --disable-verity --disable-verification flash vbmeta_vendor_a vbmeta_vendor_a.bin
 fastboot --disable-verity --disable-verification flash vbmeta_vendor_a vbmeta_vendor_b.bin
 ```
-- Download the `super.img` from your device using MTKClient or use the `super.bin` file from your backup (renamed to `super.img`).
+- Download the **super.img** from your device using MTKClient or use the **super.bin** file from your backup (renamed to **super.img**).
 
 ## Use the scripts:
 
@@ -43,4 +46,11 @@ fastboot --disable-verity --disable-verification flash vbmeta_vendor_a vbmeta_ve
 ./unmountall.sh                                # unmount partitions and remove /tmp
 ./remake.sh                                    # remake your super into super.new.img
 ```
-- Flash the remade `super.new.img` using either the GUI: `python mtk_gui` or the CLI: `python mtk w super super.new.img`.
+- Flash the remade **super.new.img** using fastboot: 
+```
+fastboot flash super super.new.img
+```
+
+### Sidenote regarding MTKClient and fastboot:
+
+MTKClient creates flashable backups of your devices and is able to restore these backups through the write option. However, it is not able to properly flash modified super images due to limitations in how it handles spare filesystems. Therefore it is recommended to use `fastboot` when flashing any images to your device, and using MTKClient only for backup.


### PR DESCRIPTION
My old instructions said to use MTKClient for flashing; which works fine in case of the backups created by it and any non-sparse filesystems (such as the boot images), but not in case of modified super images. A sidenote has been added to the bottom explaining this for future users, too.